### PR TITLE
修复R4S重启后MAC地址变更引起的PPPOE拨号失败

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -28,6 +28,7 @@ rockchip_setup_macs()
 	local label_mac=""
 
 	case "$board" in
+	friendlyarm,nanopi-r4s |\
 	friendlyarm,nanopi-r2s)
 		wan_mac=$(macaddr_random)
 		lan_mac=$(macaddr_add "$wan_mac" +1)

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -8,9 +8,7 @@ rockchip_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
-	friendlyarm,nanopi-r2s)
-		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
-		;;
+	friendlyarm,nanopi-r2s|\
 	friendlyarm,nanopi-r4s)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
@@ -28,8 +26,8 @@ rockchip_setup_macs()
 	local label_mac=""
 
 	case "$board" in
-	friendlyarm,nanopi-r4s |\
-	friendlyarm,nanopi-r2s)
+	friendlyarm,nanopi-r2s|\
+	friendlyarm,nanopi-r4s)
 		wan_mac=$(macaddr_random)
 		lan_mac=$(macaddr_add "$wan_mac" +1)
 		;;


### PR DESCRIPTION
未处理前R4S重启后PPPOE拨号失败，因为MAC地址改变。

这个纯照抄R2S的方式

MAC地址变更造成PPPOE拨号失败也可能是地区原因

（呃。。。还剩个WAN、LAN指示灯不亮的问题了--）